### PR TITLE
9999435-ant-hardcoded-absolute-paths

### DIFF
--- a/src/tutorial/tasks-filesets-properties/04-lists/build.xml
+++ b/src/tutorial/tasks-filesets-properties/04-lists/build.xml
@@ -67,10 +67,11 @@
     </target>
 
     <target name="use.simple2" depends="use.init">
+                <property name="fileset_dir_path_bgmvjue" value="c:/seu"/>
         <find file="ant.jar" location="location.ant-jar" delimiter=";">
             <path>
                 <fileset dir="${ant.home}" includes="**/*.jar"/>
-                <fileset dir="c:/seu" includes="ant*/**/*.jar"/>
+                <fileset dir="${fileset_dir_path_bgmvjue}" includes="ant*/**/*.jar"/>
             </path>
         </find>
         <echo>ant.jar found on ${location.ant-jar}</echo>


### PR DESCRIPTION
806643537These tasks reference attributes which contain hardcoded absolute paths. Consider changing these absolute paths to relative paths, or moving these paths to environment properties.<br/>CAP issue id: 806643537