### PR TITLE
9999435-ant-hardcoded-absolute-paths

### DIFF
--- a/src/tutorial/tasks-filesets-properties/04-lists/build.xml
+++ b/src/tutorial/tasks-filesets-properties/04-lists/build.xml
@@ -57,10 +57,11 @@
     </target>
 
     <target name="use.simple" depends="use.init">
+    <property name="fileset_dir_czbdclx" value="c:/seu"/>
         <find file="ant.jar" location="location.ant-jar">
             <path>
                 <fileset dir="${ant.home}" includes="**/*.jar"/>
-                <fileset dir="c:/seu" includes="ant*/**/*.jar"/>
+                <fileset dir="${fileset_dir_czbdclx}" includes="ant*/**/*.jar"/>
             </path>
         </find>
         <echo>ant.jar found on ${location.ant-jar}</echo>


### PR DESCRIPTION
806643538These tasks reference attributes which contain hardcoded absolute paths. Consider changing these absolute paths to relative paths, or moving these paths to environment properties.<br/>CAP issue id: 806643538